### PR TITLE
refactor: add basic type hints to OCR and LLM modules

### DIFF
--- a/engine/llm.py
+++ b/engine/llm.py
@@ -5,9 +5,10 @@ Local LLM adapter (optional).
 """
 import os
 import json
+from typing import Optional
 
-OLLAMA_URL = os.environ.get("LTA_OLLAMA_URL")  # e.g., http://localhost:11434
-OLLAMA_MODEL = os.environ.get("LTA_OLLAMA_MODEL", "llama2")
+OLLAMA_URL: Optional[str] = os.environ.get("LTA_OLLAMA_URL")  # e.g., http://localhost:11434
+OLLAMA_MODEL: str = os.environ.get("LTA_OLLAMA_MODEL", "llama2")
 
 def _extractive_summary(text: str, max_sentences: int = 3) -> str:
     # naive sentence split
@@ -16,7 +17,7 @@ def _extractive_summary(text: str, max_sentences: int = 3) -> str:
         return ""
     return ". ".join(sentences[:max_sentences]) + (". " if len(sentences) > 0 else "")
 
-def summarize(text: str, question: str = None) -> str:
+def summarize(text: str, question: Optional[str] = None) -> str:
     if OLLAMA_URL:
         try:
             import requests  # local import to keep dependency optional

--- a/engine/ocr_processor.py
+++ b/engine/ocr_processor.py
@@ -6,11 +6,11 @@ Functions:
 """
 import io
 import streamlit as st
-from typing import List
+from typing import Any, List
 
 # Load the cached model
 @st.cache_resource(show_spinner=False)
-def load_easyocr_reader():
+def load_easyocr_reader() -> Any:
     """Loads the heavy OCR model into memory only once."""
     print("Loading OCR Model into Memory...")
     import easyocr


### PR DESCRIPTION
Summary
Adds lightweight type hints to improve readability and tooling support.

Changes
- `engine/ocr_processor.py`: Added `Any` type hint for `load_easyocr_reader()` return
- `engine/llm.py`: Added `Optional[str]` for `OLLAMA_URL`, `str` for `OLLAMA_MODEL`, and `Optional[str]` for `summarize()` question parameter

Testing
```bash
pytest [test_llm.py](http://_vscodecontentref_/0) [test_ocr_processor.py](http://_vscodecontentref_/1) -v
28 passed ✅