### PR TITLE
DB: mapping audit trail for insert/update/import

### DIFF
--- a/engine/mapping_logic.py
+++ b/engine/mapping_logic.py
@@ -117,6 +117,18 @@ def add_mapping(ipc_section: str, bns_section: str,
     Add a new IPC to BNS mapping at runtime.
     """
     key = str(ipc_section).strip()
+
+    # Backward compatibility for older positional calls:
+    # add_mapping(ipc, bns, notes, source, persist=False)
+    if notes == "" and source == "user" and category == "User Added":
+        if bns_full_text:
+            notes = ipc_full_text
+            source = bns_full_text
+            ipc_full_text = ""
+            bns_full_text = ""
+        elif ipc_full_text:
+            notes = ipc_full_text
+            ipc_full_text = ""
     
     # Update dictionary immediately
     mapping_data = {
@@ -129,7 +141,16 @@ def add_mapping(ipc_section: str, bns_section: str,
     }
     
     if persist:
-        success = db.insert_mapping(key, bns_section, ipc_full_text, bns_full_text, notes, source, category)
+        success = db.upsert_mapping(
+            ipc_section=key,
+            bns_section=bns_section,
+            ipc_full_text=ipc_full_text,
+            bns_full_text=bns_full_text,
+            notes=notes,
+            source=source,
+            category=category,
+            actor="ui",
+        )
         if success:
             _mappings[key] = mapping_data
         return success

--- a/tests/test_db_utilities.py
+++ b/tests/test_db_utilities.py
@@ -1,0 +1,30 @@
+from engine import db
+
+
+def test_audit_trail_records_insert_and_update(tmp_path, monkeypatch):
+    test_db = tmp_path / "audit.sqlite"
+    monkeypatch.setattr(db, "_DB_FILE", str(test_db))
+    db.initialize_db()
+
+    assert db.upsert_mapping(
+        ipc_section="111",
+        bns_section="BNS 111",
+        notes="note",
+        source="test",
+        category="cat",
+        actor="test_case",
+    )
+    assert db.upsert_mapping(
+        ipc_section="111",
+        bns_section="BNS 222",
+        notes="note2",
+        source="test",
+        category="cat",
+        actor="test_case",
+    )
+
+    audit = db.get_mapping_audit("111", limit=10)
+    assert len(audit) >= 2
+    actions = [a["action"] for a in audit]
+    assert "insert" in actions
+    assert "update" in actions


### PR DESCRIPTION
## Summary
Adds a persistent audit trail for IPC→BNS mapping mutations.

## Changes
- Added `mapping_audit` table.
- Added audit logging for insert/update/upsert/import flows.
- Added helper to query recent audit records.
- Updated mapping persistence path to use audited upserts.
- Added tests for insert/update audit behavior.

## Issue
Closes #47

## Validation
- `pytest -q tests/test_db_utilities.py tests/test_mapping_logic.py`