### PR TITLE
DB: backup/restore utilities with integrity checks

### DIFF
--- a/tests/test_db_backup_restore.py
+++ b/tests/test_db_backup_restore.py
@@ -1,0 +1,27 @@
+import os
+import sqlite3
+
+from engine import db
+
+
+def test_backup_and_restore(tmp_path, monkeypatch):
+    test_db = tmp_path / "main.sqlite"
+    backup_db = tmp_path / "backup.sqlite"
+    monkeypatch.setattr(db, "_DB_FILE", str(test_db))
+    db.initialize_db()
+    assert db.insert_mapping("420", "BNS 318", "x", "y", "z")
+
+    backup_path = db.backup_database(str(backup_db))
+    assert backup_path is not None
+    assert os.path.exists(backup_path)
+
+    # Corrupt current DB then restore
+    with open(test_db, "wb") as f:
+        f.write(b"not a sqlite db")
+
+    assert db.restore_database(str(backup_db)) is True
+    conn = sqlite3.connect(str(test_db))
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM mappings")
+    assert cur.fetchone()[0] >= 1
+    conn.close()


### PR DESCRIPTION
## Summary
Adds operational backup/restore utilities for mapping database with integrity checks.

## Changes
- Added `backup_database()` with timestamped backup support.
- Added `restore_database()` with SQLite integrity verification.
- Added internal `_check_sqlite_integrity()` helper.
- Added test for backup/restore success path.

## Issue
Closes #52

## Validation
- `pytest -q tests/test_db_backup_restore.py`