### PR TITLE
Deprecated API Usage

### DIFF
--- a/app.py
+++ b/app.py
@@ -250,19 +250,12 @@ def render_agent_audio(audio_path, title="🎙️ AI Agent Dictation"):
 def _read_url_page():
     try:
         qp = st.query_params
-        try:
-            val = qp.get("page", None)
-        except Exception:
-            try:
-                val = dict(qp).get("page", None)
-            except Exception:
-                val = None
+        val = qp.get("page", None)
         if isinstance(val, list):
             return val[0]
         return val
     except Exception:
-        qp = st.experimental_get_query_params()
-        return qp.get("page", [None])[0] if qp else None
+        return None
 
 
 url_page = _read_url_page()


### PR DESCRIPTION
## Changes made:

- Removed the deprecated st.experimental_get_query_params() fallback block (lines 159-161)
- Simplified the _read_url_page() function to use only st.query_params, which is the modern Streamlit approach

Before:


```
def _read_url_page():
    try:
        qp = st.query_params
        try:
            val = qp.get("page", None)
        except Exception:
            try:
                val = dict(qp).get("page", None)
            except Exception:
                val = None
        if isinstance(val, list):
            return val[0]
        return val
    except Exception:
        qp = st.experimental_get_query_params()
        return qp.get("page", [None])[0] if qp else None
```
After:


```
def _read_url_page():
    try:
        qp = st.query_params
        val = qp.get("page", None)
        if isinstance(val, list):
            return val[0]
        return val
    except Exception:
        return None
```

The code now uses the current st.query_params API as recommended by Streamlit, eliminating the deprecated experimental_get_query_params() function.

closes #104